### PR TITLE
Anonymously log usage of Uma Launcher.

### DIFF
--- a/umalauncher/threader.py
+++ b/umalauncher/threader.py
@@ -96,6 +96,8 @@ class Threader():
 @logger.catch
 def main():
     logger.info("==== Starting Launcher ====")
+    # Log the use of Uma Launcher anonymously.
+    util.do_get_request(f"https://umapyoi.net/api/v1/umalauncher/startup/{util.make_mac_hash()}")
     Threader()
 
 if __name__ == "__main__":

--- a/umalauncher/util.py
+++ b/umalauncher/util.py
@@ -143,10 +143,11 @@ def make_mac_hash():
     """Creates an anonymous hash from the mac address.
     This is used to log unique users without being able identify them.
 
-    When mac == -1, hash = a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89
+    When mac == -1, hash = 5bb2bd03350ba8709a490e092c075e43a22b1c3a75d717ed3bb015ec006d7b65
     """
     mac = get_mac()
-    return hashlib.sha256(mac.to_bytes(mac.bit_length(), 'big', signed=True)).hexdigest()
+    salt = b"umalauncher psRa5IZ9cwoz9Y7Q60x8SB2FUZt5kedd"
+    return hashlib.sha256(mac.to_bytes(mac.bit_length(), 'big', signed=True) + salt).hexdigest()
 
 
 window_handle = None

--- a/umalauncher/util.py
+++ b/umalauncher/util.py
@@ -90,6 +90,8 @@ import requests
 from pywintypes import error as pywinerror  # pylint: disable=no-name-in-module
 from PIL import Image
 import numpy as np
+import uuid
+import hashlib
 import mdb
 import gui
 
@@ -119,6 +121,32 @@ def do_get_request(url, error_title=None, error_message=None, ignore_timeout=Fal
         if not ignore_timeout:
             last_failed_request = time.perf_counter()
         return None
+
+
+def get_mac():
+    """Custom mac address getter function that returns -1 if no mac address is found.
+    """
+    if uuid._node is not None:
+        return uuid._node
+
+    _node = None
+    for getter in uuid._GETTERS:
+        try:
+            _node = getter()
+        except:
+            continue
+        if (_node is not None) and (0 <= _node < (1 << 48)):
+            return _node
+    return -1
+
+def make_mac_hash():
+    """Creates an anonymous hash from the mac address.
+    This is used to log unique users without being able identify them.
+
+    When mac == -1, hash = a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89
+    """
+    mac = get_mac()
+    return hashlib.sha256(mac.to_bytes(mac.bit_length(), 'big', signed=True)).hexdigest()
 
 
 window_handle = None


### PR DESCRIPTION
I'd like to get a clear picture of how many users actually use Uma Launcher.
I found out this cannot be done simply by looking at IP addresses for the calls to umapyoi.net, because many users are required to use a VPN connection to use the game. This creates a problem because a single user won't keep the same IP address all the time. (And even without VPN, dynamic IP addresses are still a thing.)
To solve this while keeping anonymity and without storing identifiable information, I'm fetching the mac address of the user and hashing it with SHA256, using a shared salt. This will result in a unique hash per mac address, that is impossible to turn back into the mac address. And with the salt, it should not be able to appear in any database of hashed mac addresses.