### PR TITLE
Anonymously log usage of Uma Launcher (fix)

### DIFF
--- a/umalauncher/settings.py
+++ b/umalauncher/settings.py
@@ -2,6 +2,7 @@ import os
 import json
 import copy
 import sys
+import uuid
 from win32com.shell import shell
 import traceback
 from loguru import logger
@@ -18,6 +19,7 @@ class Settings():
     default_settings = {
         "_version": version.VERSION,
         "_skip_update": None,
+        "_unique_id": str(uuid.uuid4()),
         "beta_optin": False,
         "debug_mode": False,
         "autoclose_dmm": True,
@@ -243,3 +245,6 @@ class Settings():
             if self.threader.carrotjuicer.helper_table:
                 self.threader.carrotjuicer.helper_table.update_presets(*self.get_helper_table_data())
             self.save_settings()
+    
+    def notify_server(self):
+        util.do_get_request(f"https://umapyoi.net/api/v1/umalauncher/startup/{self.loaded_settings['_unique_id']}")

--- a/umalauncher/threader.py
+++ b/umalauncher/threader.py
@@ -43,6 +43,9 @@ class Threader():
         # Set directory to find assets
         self.settings = settings.Settings(self)
 
+        # Ping the server to track usage
+        self.settings.notify_server()
+
         self.screenstate = screenstate.ScreenStateHandler(self)
         self.threads.append(threading.Thread(target=self.screenstate.run, name="ScreenStateHandler"))
 

--- a/umalauncher/util.py
+++ b/umalauncher/util.py
@@ -90,8 +90,6 @@ import requests
 from pywintypes import error as pywinerror  # pylint: disable=no-name-in-module
 from PIL import Image
 import numpy as np
-import uuid
-import hashlib
 import mdb
 import gui
 


### PR DESCRIPTION
Revert the mac address idea and simply generate a completely random unique ID that the user can control/reset if they so wish to. This way, I am storing absolutely nothing that could be traced back or ever joined with other data in the event my database gets compromised, because I am not storing any personal or identifiable data in this way.